### PR TITLE
Add Entities, Enums, and JSON Conversion for Shipping API

### DIFF
--- a/src/main/java/com/fawry/shipping_api/entity/DeliveryPerson.java
+++ b/src/main/java/com/fawry/shipping_api/entity/DeliveryPerson.java
@@ -1,0 +1,33 @@
+package com.fawry.shipping_api.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "delivery_persons")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeliveryPerson {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long personId;
+
+    private String name;
+
+    private String email;
+
+    @Column(unique = true)
+    private String phoneNumber;
+
+    private Boolean isActive = true;
+
+    @Column(updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    private LocalDateTime updatedAt = LocalDateTime.now();
+}

--- a/src/main/java/com/fawry/shipping_api/entity/DeliveryPersonWorkArea.java
+++ b/src/main/java/com/fawry/shipping_api/entity/DeliveryPersonWorkArea.java
@@ -1,0 +1,49 @@
+package com.fawry.shipping_api.entity;
+
+import com.fawry.shipping_api.enums.DayOfWeek;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Entity
+@Table(name = "delivery_person_work_areas")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeliveryPersonWorkArea {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long workAreaId;
+
+    @ManyToOne
+    @JoinColumn(name = "delivery_person_id", nullable = false)
+    private DeliveryPerson deliveryPerson;
+
+    @Column(nullable = false)
+    private Long governorateId;
+
+    @Column(nullable = false)
+    private Long cityId;
+
+    @ElementCollection(targetClass = DayOfWeek.class)
+    @CollectionTable(name = "work_area_days",
+            joinColumns = @JoinColumn(name = "work_area_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "work_day", nullable = false)
+    private Set<DayOfWeek> workDays;
+
+    @Column(updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/fawry/shipping_api/entity/OrderShipment.java
+++ b/src/main/java/com/fawry/shipping_api/entity/OrderShipment.java
@@ -1,0 +1,48 @@
+package com.fawry.shipping_api.entity;
+
+import com.fawry.shipping_api.enums.ShippingStatus;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "order_shipments")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderShipment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long shipmentId;
+
+    private Long orderId;
+
+    private Long governorateId;
+
+    private Long cityId;
+
+    private String customerAddress;
+
+    @ManyToOne
+    @JoinColumn(name = "delivery_person_id")
+    private DeliveryPerson deliveryPerson;
+
+    private String trackingToken;
+
+    private String confirmationCode;
+
+    @Enumerated(EnumType.STRING)
+    private ShippingStatus status;
+
+    private LocalDateTime expectedDeliveryDate;
+
+    private LocalDateTime deliveredAt;
+
+    @Column(updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    private LocalDateTime updatedAt = LocalDateTime.now();
+}

--- a/src/main/java/com/fawry/shipping_api/enums/DayOfWeek.java
+++ b/src/main/java/com/fawry/shipping_api/enums/DayOfWeek.java
@@ -1,0 +1,11 @@
+package com.fawry.shipping_api.enums;
+
+public enum DayOfWeek {
+    MONDAY,
+    TUESDAY,
+    WEDNESDAY,
+    THURSDAY,
+    FRIDAY,
+    SATURDAY,
+    SUNDAY
+}

--- a/src/main/java/com/fawry/shipping_api/enums/ShippingStatus.java
+++ b/src/main/java/com/fawry/shipping_api/enums/ShippingStatus.java
@@ -1,0 +1,9 @@
+package com.fawry.shipping_api.enums;
+
+public enum ShippingStatus {
+    ORDER_RECEIVED,
+    PROCESSING_ORDER,
+    ORDER_SHIPPED,
+    ORDER_DELIVERED,
+    ORDER_CANCELLED
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-      active: test
+      active: dev
   application:
     name:
      Shipping-API


### PR DESCRIPTION
## Description

This PR introduces the following components to the Shipping API:

1. **Entities**:
   - `DeliveryPerson`: Represents delivery personnel with attributes such as name, email, phone number, and status.
   - `OrderShipment`: Captures shipment details including order ID, customer address, delivery person, and status.
   - `DeliveryPersonWorkArea`: Defines the work areas for delivery personnel, including governorate and city IDs, and work days.

2. **Enums**:
   - `ShippingStatus`: Enumerates possible shipment statuses such as ORDER_RECEIVED, PROCESSING_ORDER, ORDER_SHIPPED, ORDER_DELIVERED, and ORDER_CANCELLED.
   - `DayOfWeek`: Enumerates days of the week from MONDAY to SUNDAY for scheduling work days.

3. **JSON Conversion**:
   - `MapToJsonConverter`: A JPA attribute converter that handles the conversion of `Map<String, Object>` to JSON strings and vice versa. This is used for storing complex data structures like work days in a JSON column.

## Key Changes

- **Entities**: Defined using JPA annotations with Lombok for boilerplate code reduction.
- **Enums**: Added to represent fixed sets of constants for shipment status and days of the week.
- **Conversion**: Implemented a custom converter to facilitate the storage of map data in JSON format.

## Benefits

- **Structured Data Management**: Enables efficient management and querying of structured data within the database.
- **Flexibility**: Provides flexibility in handling dynamic data structures through JSON storage.
- **Code Simplification**: Utilizes Lombok to reduce boilerplate code, improving maintainability.
