### PR TITLE
[FAWRY-15] feat: Implement createShippingOrder in Shipping Service for Order Saga

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.4.3</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath/>
 	</parent>
 	<groupId>com.fawry</groupId>
 	<artifactId>Shipping-API</artifactId>
@@ -97,9 +97,8 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
-							<version>1.18.32</version> <!-- حدد الإصدار بشكل صريح -->
+							<version>1.18.32</version>
 						</path>
-						<!-- أضف معالجات أخرى مطلوبة (مثل Spring Boot) -->
 						<path>
 							<groupId>org.springframework.boot</groupId>
 							<artifactId>spring-boot-configuration-processor</artifactId>

--- a/src/main/java/com/fawry/shipping_api/controller/ShipmentController.java
+++ b/src/main/java/com/fawry/shipping_api/controller/ShipmentController.java
@@ -17,13 +17,6 @@ import java.util.List;
 public class ShipmentController {
     private final ShipmentService shipmentService;
 
-
-    @PostMapping
-    public ResponseEntity<ShipmentDetails> createShipment(
-            @Valid @RequestBody CreateShipment createShipment) {
-        return ResponseEntity.ok(shipmentService.createShipment(createShipment));
-    }
-
     // === Admin Endpoints ===
 
     @GetMapping

--- a/src/main/java/com/fawry/shipping_api/dto/AddressDetails.java
+++ b/src/main/java/com/fawry/shipping_api/dto/AddressDetails.java
@@ -1,0 +1,17 @@
+package com.fawry.shipping_api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class AddressDetails {
+    private String governorate;
+    private String city;
+    private String address;
+
+}

--- a/src/main/java/com/fawry/shipping_api/dto/shipment/CreateShipment.java
+++ b/src/main/java/com/fawry/shipping_api/dto/shipment/CreateShipment.java
@@ -1,7 +1,9 @@
 package com.fawry.shipping_api.dto.shipment;
 
 import com.fawry.shipping_api.dto.customer.CustomerDetails;
+import lombok.Builder;
 
+@Builder(toBuilder = true)
 public record CreateShipment(
         Long orderId,
         CustomerDetails customerDetails

--- a/src/main/java/com/fawry/shipping_api/kafka/events/PaymentCreatedEventDTO.java
+++ b/src/main/java/com/fawry/shipping_api/kafka/events/PaymentCreatedEventDTO.java
@@ -1,0 +1,23 @@
+package com.fawry.shipping_api.kafka.events;
+
+import com.fawry.shipping_api.dto.AddressDetails;
+import lombok.*;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+@ToString
+public class PaymentCreatedEventDTO implements Serializable {
+    private Long orderId;
+    private Long userId;
+    private String customerEmail;
+    private String customerName;
+    private String customerContact;
+    private AddressDetails addressDetails;
+    private BigDecimal paymentAmount;
+}

--- a/src/main/java/com/fawry/shipping_api/kafka/events/ShippingStatusEvent.java
+++ b/src/main/java/com/fawry/shipping_api/kafka/events/ShippingStatusEvent.java
@@ -2,7 +2,6 @@ package com.fawry.shipping_api.kafka.events;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fawry.shipping_api.enums.ShippingStatus;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 

--- a/src/main/java/com/fawry/shipping_api/kafka/producer/ShippingProducer.java
+++ b/src/main/java/com/fawry/shipping_api/kafka/producer/ShippingProducer.java
@@ -10,6 +10,8 @@ import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
+
+
 @Service
 public class ShippingProducer<T extends ShippingBaseEvent> {
     private final Logger log = LoggerFactory.getLogger(ShippingProducer.class);

--- a/src/main/java/com/fawry/shipping_api/mapper/CustomerMapper.java
+++ b/src/main/java/com/fawry/shipping_api/mapper/CustomerMapper.java
@@ -2,6 +2,7 @@ package com.fawry.shipping_api.mapper;
 
 import com.fawry.shipping_api.dto.customer.CustomerDetails;
 import com.fawry.shipping_api.entity.Customer;
+import com.fawry.shipping_api.kafka.events.PaymentCreatedEventDTO;
 import lombok.Builder;
 import org.springframework.stereotype.Component;
 
@@ -32,4 +33,6 @@ public class CustomerMapper {
                 .name(customer.getName())
                 .build();
     }
+
+
 }

--- a/src/main/java/com/fawry/shipping_api/mapper/ShipmentMapper.java
+++ b/src/main/java/com/fawry/shipping_api/mapper/ShipmentMapper.java
@@ -1,8 +1,11 @@
 package com.fawry.shipping_api.mapper;
 
+import com.fawry.shipping_api.dto.customer.CustomerDetails;
+import com.fawry.shipping_api.dto.shipment.CreateShipment;
 import com.fawry.shipping_api.dto.shipment.ShipmentDetails;
 import com.fawry.shipping_api.dto.shipment.ShipmentTracking;
 import com.fawry.shipping_api.entity.Shipment;
+import com.fawry.shipping_api.kafka.events.PaymentCreatedEventDTO;
 import com.fawry.shipping_api.kafka.events.ShippingDetailsEvent;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -42,6 +45,24 @@ public class ShipmentMapper {
                 .deliveryPersonName(shipment.getDeliveryPerson()!=null ? shipment.getDeliveryPerson().getName():null)
                 .status(shipment.getStatus())
                 .expectedDeliveryDate(shipment.getExpectedDeliveryDate())
+                .build();
+    }
+
+    public CreateShipment toShippingOrderDetails(PaymentCreatedEventDTO paymentCreatedEventDTO) {
+        return CreateShipment
+                .builder()
+                .orderId(paymentCreatedEventDTO.getOrderId())
+                .customerDetails(
+                        CustomerDetails
+                                .builder()
+                                .governorate(paymentCreatedEventDTO.getAddressDetails().getGovernorate())
+                                .city(paymentCreatedEventDTO.getAddressDetails().getCity())
+                                .address(paymentCreatedEventDTO.getAddressDetails().getAddress())
+                                .name(paymentCreatedEventDTO.getCustomerName())
+                                .email(paymentCreatedEventDTO.getCustomerEmail())
+                                .phone(paymentCreatedEventDTO.getCustomerContact())
+                                .build()
+                )
                 .build();
     }
 

--- a/src/main/java/com/fawry/shipping_api/service/ShipmentService.java
+++ b/src/main/java/com/fawry/shipping_api/service/ShipmentService.java
@@ -1,12 +1,15 @@
 package com.fawry.shipping_api.service;
 
 import com.fawry.shipping_api.dto.shipment.*;
+import com.fawry.shipping_api.kafka.events.PaymentCreatedEventDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface ShipmentService {
+    void shipOrder(PaymentCreatedEventDTO shippedDetails);
+
     ShipmentDetails createShipment(CreateShipment createShipment);
 
     Page<ShipmentDetails> getShipments(int page, int size, String sortBy);

--- a/src/main/java/com/fawry/shipping_api/service/impl/CustomerServiceImpl.java
+++ b/src/main/java/com/fawry/shipping_api/service/impl/CustomerServiceImpl.java
@@ -1,5 +1,6 @@
 package com.fawry.shipping_api.service.impl;
 
+
 import com.fawry.shipping_api.dto.customer.CustomerDetails;
 import com.fawry.shipping_api.entity.Customer;
 import com.fawry.shipping_api.mapper.CustomerMapper;
@@ -9,6 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 
 import java.util.Optional;
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,11 +1,16 @@
 server:
-  port: 3031
+  port: 5555
+
+frontend:
+  url: http://localhost
+  port: 4200
+
 spring:
   datasource:
     driver: org.postgresql.Driver
     url: jdbc:postgresql://localhost:5432/shipping_db
     username: postgres
-    password: postgres
+    password: 12345
 
   jpa:
     properties:
@@ -20,6 +25,35 @@ spring:
   liquibase:
     enabled: true
     change-log: classpath:db/changelog/db.changelog-master.xml
+  # Kafka Config
+  kafka:
+    listener:
+      missing-topics-fatal: false
+      ack-mode: RECORD
+    consumer:
+      enable-auto-commit: true
+      bootstrap-servers: localhost:9092
+      group-id: ship_payment_id
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        allow.auto.create.topics: true
+        spring.json.trusted.packages: "com.fawry.kafka.events"
+        spring.json.type.mapping:
+          paymentCreatedEventDTO:com.fawry.shipping_api.kafka.events.PaymentCreatedEventDTO
+
+    producer:
+      bootstrap-servers: localhost:9092
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: true
+        spring.json.type.mapping:
+          shippingStatusEvent:com.fawry.shipping_api.kafka.events.ShippingStatusEvent,
+          shippingDetailsEvent:com.fawry.shipping_api.kafka.events.ShippingDetailsEvent
+        acks: all
+        retries: 3
 
 eureka:
   client:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-      active: dev
+      active: test
   application:
     name:
      Shipping-API


### PR DESCRIPTION
Close #15 #14 
This PR implements the createShippingOrder method in the Shipping Service as part of the Order Saga Distributed Transaction. The Shipping Service listens for PaymentCreatedEventDTO events on the payment-updated-events topic, creates a ShippingOrder with the customer’s details (e.g., address, contact), and saves it to the database. After successful creation, it publishes a ShippingOrderCreatedEventDTO event to notify other services (e.g., the Order Service) to update the order status. If any failure occurs, it publishes an OrderCanceledEventDTO event to cancel the order. The @Transactional annotation ensures atomicity of the shipping order creation, and logging is added for observability.

Changes:
Added createShippingOrder method in ShippingService to handle PaymentCreatedEventDTO from payment-updated-events topic.
Created ShippingOrder entity and saved it to the database with customer details from the event.
Published ShippingOrderCreatedEventDTO to notify other services of successful shipping order creation.
Handled failures by publishing OrderCanceledEventDTO to cancel the order.
Used @Transactional to ensure atomicity of shipping order creation.